### PR TITLE
Formatting and Bugfixes

### DIFF
--- a/.github/workflows/run_hardware_node_deploy.yml
+++ b/.github/workflows/run_hardware_node_deploy.yml
@@ -3,12 +3,12 @@ name: Hardware Nodes Deploy
 on:
   push:
     branches:
-       - "main"
+       - main
     
     paths:
-    - "src/ros2/hardware_nodes/**"
-    - "src/ros2/communication_interfaces/**"
-    - "libs/**"
+    - src/ros2/hardware_nodes/**
+    - src/ros2/communication_interfaces/**
+    - libs/**
       
 jobs:
   deploy:

--- a/.github/workflows/run_hardware_node_tests.yml
+++ b/.github/workflows/run_hardware_node_tests.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - src/ros2/hardware_nodes/*
-      - src/ros2/communication_interfaces/*
-      - .github/workflows/*
+      - src/ros2/hardware_nodes/**
+      - src/ros2/communication_interfaces/**
+      - .github/workflows/**
        
 jobs:
   test-run-hardware_nodes:

--- a/.github/workflows/run_navigation_deploy .yml
+++ b/.github/workflows/run_navigation_deploy .yml
@@ -3,10 +3,10 @@ name: Navigation Deploy
 on:
   push:
     branches:
-      - "main"
+      - main
     paths:
-    - "src/ros2/navigation/**"
-    - "src/ros2/communication_interfaces/**"
+    - src/ros2/navigation/**
+    - src/ros2/communication_interfaces/**
       
 jobs:
   deploy:

--- a/.github/workflows/run_simple_fleetmanagement_deploy.yml
+++ b/.github/workflows/run_simple_fleetmanagement_deploy.yml
@@ -3,10 +3,10 @@ name: simple fleetmanagement Deploy
 on:
   push:
     branches:
-      - "main"
+      - main
     paths:
-    - "src/ros2/simple_fleetmanagement/**"
-    - "src/ros2/communication_interfaces/**"
+    - src/ros2/simple_fleetmanagement/**
+    - src/ros2/communication_interfaces/**
       
 jobs:
   deploy:

--- a/.github/workflows/run_statemachine_tests.yml
+++ b/.github/workflows/run_statemachine_tests.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - src/ros2/statemachine/*
-      - src/ros2/communication_interfaces/*
-      - .github/workflows/*
+      - src/ros2/statemachine/**
+      - src/ros2/communication_interfaces/**
+      - .github/workflows/**
        
 jobs:
   test-run-statemachine:

--- a/.github/workflows/run_web_deploy.yml
+++ b/.github/workflows/run_web_deploy.yml
@@ -3,9 +3,9 @@ name: Web Deploy
 on:
   push:
     branches:
-      - "main"
+      - main
     paths:
-    - "src/web/**"
+    - src/web/**
       
 jobs:
   deploy:


### PR DESCRIPTION
Small Bug-fixes to make the tests Run again

- we had some guideline breaks regarding when to use quotes which had in the moment only cosmetic concerns 
 - we used in tests workflows  * instead of ** so that only changes in the first children were considered instead of with ** the lookup range were increased to all levels below.  