### PR TITLE
Bridge the info topics from Gazebo to ROS2

### DIFF
--- a/src/ros2/simulation/tiplu_world/config/gz_ros_bridge.yaml
+++ b/src/ros2/simulation/tiplu_world/config/gz_ros_bridge.yaml
@@ -92,6 +92,15 @@
   lazy: true               # Default "false"
   direction: GZ_TO_ROS
 
+- ros_topic_name: "back_top_oak_d_camera/color_camera_info"
+  gz_topic_name: "/back_top_oak_d_camera/back_top_oak_d_camera/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
+  gz_type_name: "gz.msgs.PointCloudPacked"
+  subscriber_queue: 10      # Default 10
+  publisher_queue: 10       # Default 10
+  lazy: true               # Default "false"
+  direction: GZ_TO_ROS
+
 - ros_topic_name: "/front_top_oak_d_camera/color"
   gz_topic_name: "/front_top_oak_d_camera/color"
   ros_type_name: "sensor_msgs/msg/Image"
@@ -113,6 +122,15 @@
 - ros_topic_name: "/front_top_oak_d_camera/depth/points"
   gz_topic_name: "/front_top_oak_d_camera/front_top_oak_d_camera/depth/points"
   ros_type_name: "sensor_msgs/msg/PointCloud2"
+  gz_type_name: "gz.msgs.PointCloudPacked"
+  subscriber_queue: 10      # Default 10
+  publisher_queue: 10       # Default 10
+  lazy: true               # Default "false"
+  direction: GZ_TO_ROS
+
+- ros_topic_name: "front_top_oak_d_camera/color_camera_info"
+  gz_topic_name: "/front_top_oak_d_camera/front_top_oak_d_camera/camera_info"
+  ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.PointCloudPacked"
   subscriber_queue: 10      # Default 10
   publisher_queue: 10       # Default 10


### PR DESCRIPTION
This PR belongs to [RE-1592](https://robast.atlassian.net/browse/RE-1592)
This PR contains:
The adjustments of the gazebo bridge to add the camera info topics of the Oak-d's

[RE-1592]: https://robast.atlassian.net/browse/RE-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ