### PR TITLE
fix: remappings for `cmd_vel` and `cmd_vel_smoothed`

### DIFF
--- a/src/ros2/navigation/nav_bringup/launch/nav_without_localization_launch.py
+++ b/src/ros2/navigation/nav_bringup/launch/nav_without_localization_launch.py
@@ -157,7 +157,8 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings),
+                remappings=remappings +
+                        [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]),
             Node(
                 package='nav2_bt_navigator',
                 executable='bt_navigator',

--- a/src/ros2/navigation/nav_bringup/launch/nav_without_localization_with_bt_server_collection_launch.py
+++ b/src/ros2/navigation/nav_bringup/launch/nav_without_localization_with_bt_server_collection_launch.py
@@ -155,7 +155,8 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings),
+                remappings=remappings +
+                        [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]),
             Node(
                 package='nav2_bt_navigator',
                 executable='bt_navigator',


### PR DESCRIPTION
Only the output of the velocity_smoother (`cmd_vel_smoothed`) should be used for the cmd_vel topic, that is directly commanding the motor control.