### PR TITLE
fix: remapping of cmd_vel for behavior_server in the simulation

### DIFF
--- a/src/ros2/navigation/nav_bringup/launch/nav_without_localization_launch.py
+++ b/src/ros2/navigation/nav_bringup/launch/nav_without_localization_launch.py
@@ -29,6 +29,7 @@ def generate_launch_description():
             ("/tf_static", "tf_static"),
             ("/cmd_vel_smoothed", "diff_drive_base_controller/cmd_vel_unstamped")
         ]
+        cmd_vel_remapping_behavior_server = [("/cmd_vel", "diff_drive_base_controller/cmd_vel_unstamped")]
     else:
         use_sim_time_default = "false"
         remappings = [
@@ -37,6 +38,7 @@ def generate_launch_description():
             ("/robot/tf_static", "tf_static"),
             ("/cmd_vel_smoothed", "robot/robotnik_base_control/cmd_vel")
         ]
+        cmd_vel_remapping_behavior_server = [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]
 
     namespace = LaunchConfiguration('namespace')
     use_sim_time = LaunchConfiguration('use_sim_time')
@@ -157,8 +159,7 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings +
-                        [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]),
+                remappings=remappings + cmd_vel_remapping_behavior_server),
             Node(
                 package='nav2_bt_navigator',
                 executable='bt_navigator',
@@ -229,7 +230,7 @@ def generate_launch_description():
                 plugin='behavior_server::BehaviorServer',
                 name='behavior_server',
                 parameters=[configured_params],
-                remappings=remappings),
+                remappings=remappings + cmd_vel_remapping_behavior_server),
             ComposableNode(
                 package='nav2_bt_navigator',
                 plugin='nav2_bt_navigator::BtNavigator',

--- a/src/ros2/navigation/nav_bringup/launch/nav_without_localization_with_bt_server_collection_launch.py
+++ b/src/ros2/navigation/nav_bringup/launch/nav_without_localization_with_bt_server_collection_launch.py
@@ -26,6 +26,7 @@ def generate_launch_description():
             ("/tf_static", "tf_static"),
             ("/cmd_vel_smoothed", "diff_drive_base_controller/cmd_vel_unstamped")
         ]
+        cmd_vel_remapping_behavior_server = [("/cmd_vel", "diff_drive_base_controller/cmd_vel_unstamped")]
     else:
         use_sim_time_default = "false"
         remappings = [
@@ -34,6 +35,7 @@ def generate_launch_description():
             ("/robot/tf_static", "tf_static"),
             ("/cmd_vel_smoothed", "robot/robotnik_base_control/cmd_vel")
         ]
+        cmd_vel_remapping_behavior_server = [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]
 
     namespace = LaunchConfiguration('namespace')
     use_sim_time = LaunchConfiguration('use_sim_time')
@@ -155,8 +157,7 @@ def generate_launch_description():
                 respawn_delay=2.0,
                 parameters=[configured_params],
                 arguments=['--ros-args', '--log-level', log_level],
-                remappings=remappings +
-                        [("/cmd_vel", "robot/robotnik_base_control/cmd_vel")]),
+                remappings=remappings + cmd_vel_remapping_behavior_server),
             Node(
                 package='nav2_bt_navigator',
                 executable='bt_navigator',
@@ -239,7 +240,7 @@ def generate_launch_description():
                 plugin='behavior_server::BehaviorServer',
                 name='behavior_server',
                 parameters=[configured_params],
-                remappings=remappings),
+                remappings=remappings + cmd_vel_remapping_behavior_server),
             ComposableNode(
                 package='nav2_bt_navigator',
                 plugin='nav2_bt_navigator::BtNavigator',


### PR DESCRIPTION
This hotfix pull request fixes the remapping of the cmd_vel topic for the behavior_server in the simulation. Without this fix, behaviors like `spin` have no effect.