### PR TITLE
robast map update module build fix

### DIFF
--- a/src/ros2/navigation/robast_map_update_module/CMakeLists.txt
+++ b/src/ros2/navigation/robast_map_update_module/CMakeLists.txt
@@ -97,6 +97,7 @@ target_include_directories(combine_grids PUBLIC
 )
 
 target_link_libraries(combine_grids ${rclcpp_LIBRARIES} ${OpenCV_LIBS})
+ament_target_dependencies(combine_grids ${DEPENDENCIES})
 
 target_link_libraries(map_combine_node combine_grids)
 


### PR DESCRIPTION
Fixes the build error of the map update module which doesn't find the nav_msgs occupancy grid