### PR TITLE
fix: increases `receiver_interval_sec` to reduce socket can warning spam (RE-2615)

### DIFF
--- a/bringups/jetson/start_scripts/hardware_nodes_start.sh
+++ b/bringups/jetson/start_scripts/hardware_nodes_start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 . /robast/humble/setup.sh
-ros2 launch ros2_socketcan socket_can_bridge.launch.xml interface:=can0 &
+ros2 launch ros2_socketcan socket_can_bridge.launch.xml interface:=can0 receiver_interval_sec:=1.0 &
 ros2 launch drawer_bridge drawer_bridge_launch.py &
 ros2 launch nfc_bridge nfc_bridge_launch.py &
 ros2 run qos_bridge error_qos_bridge &


### PR DESCRIPTION
### Description
What:
- the warning occurs when the socket can driver does not receive any can msg withing the time of `receiver_interval_sec`. Because we have the heartbeats coming in every second, we can increase the `receiver_interval_sec` to 1 sec and stop the warning spam

How:

Link to Jira Ticket: 
https://robast.atlassian.net/browse/RE-2615
---

### Code Checklist
- [ ] tested
- [ ] documented
