### PR TITLE
style: adds `IndentAccessModifiers` and `ContinuationIndentWidth` to `.clang-format`

### DIFF
--- a/project_startups/hardware_nodes_drawer/.clang-format
+++ b/project_startups/hardware_nodes_drawer/.clang-format
@@ -4,7 +4,6 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -15,11 +14,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
 AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
 SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/hardware_nodes_full_stack/.clang-format
+++ b/project_startups/hardware_nodes_full_stack/.clang-format
@@ -2,8 +2,8 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -14,11 +14,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
 AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
 SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/moveit/.clang-format
+++ b/project_startups/moveit/.clang-format
@@ -2,8 +2,8 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -14,11 +14,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
 AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
 SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/navigation/.clang-format
+++ b/project_startups/navigation/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/perception/.clang-format
+++ b/project_startups/perception/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/platformio/Drawer_Controller/.clang-format
+++ b/project_startups/platformio/Drawer_Controller/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation/hardware_nodes/.clang-format
+++ b/project_startups/simulation/hardware_nodes/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation/navigation/.clang-config
+++ b/project_startups/simulation/navigation/.clang-config
@@ -2,23 +2,19 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation/navigation/.clang-format
+++ b/project_startups/simulation/navigation/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation/perception/.clang-format
+++ b/project_startups/simulation/perception/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation/simulation/.clang-format
+++ b/project_startups/simulation/simulation/.clang-format
@@ -2,23 +2,19 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation_moveit/moveit/.clang-format
+++ b/project_startups/simulation_moveit/moveit/.clang-format
@@ -4,7 +4,6 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
@@ -15,11 +14,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
 AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
 SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation_moveit/navigation/.clang-format
+++ b/project_startups/simulation_moveit/navigation/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation_moveit/perception/.clang-format
+++ b/project_startups/simulation_moveit/perception/.clang-format
@@ -4,22 +4,17 @@ BasedOnStyle: Google
 IndentWidth: 2
 ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/simulation_moveit/simulation/.clang-format
+++ b/project_startups/simulation_moveit/simulation/.clang-format
@@ -2,23 +2,19 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
-
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortLambdasOnASingleLine: None
+BreakBeforeBraces: Allman
 BinPackParameters: false # If false, a function call’s arguments will either be all on the same line or will have one line each.
 BinPackArguments: false # If false, a function call’s parameters will either be all on the same line or will have one line each.
-BreakBeforeBraces: Allman
 AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
+AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
-
 UseCRLF: false # use \n instead of \r\n
-
-SpaceAfterCStyleCast: true  # does (int) x instead of (int)x
+SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers

--- a/project_startups/statemachine/.clang-format
+++ b/project_startups/statemachine/.clang-format
@@ -2,6 +2,7 @@
 # options: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Google
 IndentWidth: 2
+ContinuationIndentWidth: 2
 ColumnLimit: 120
 UseTab: Never
 AllowShortIfStatementsOnASingleLine: false
@@ -13,8 +14,7 @@ AlignTrailingComments: true
 SpacesBeforeTrailingComments: 3
 AllowShortLambdasOnASingleLine: None
 NamespaceIndentation: All # enables the indenting for a namespace
-#  #define SHORT_NAME       42
-#  #define LONGER_NAME      0x007f   # does nice spacing for macros
 AlignConsecutiveMacros: Consecutive
 UseCRLF: false # use \n instead of \r\n
 SpaceAfterCStyleCast: true # does (int) x instead of (int)x
+IndentAccessModifiers: true # aligns access modifiers


### PR DESCRIPTION
### Description
What:
- fixes the indenting of the access modifiers

How:

Link to Jira Ticket: 

---

### Code Checklist
- [ ] tested
- [ ] documented
